### PR TITLE
Initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ vendor/engines/
 yarn-debug.log*
 .yarn-integrity
 spec/tmp/pdfs
+/public/test-assets/
 
 # Ignore solr generated files
 solr/config/*

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,6 +29,11 @@ collection_types.each do |c|
   puts "#{oldtitle} changed to #{c.title}"
 end
 
+puts "\n== Adding user to admin role"
+admin = Role.create(name: "admin")
+admin.users << User.first
+admin.save
+
 puts "\n== Loading workflows"
 Hyrax::Workflow::WorkflowImporter.load_workflows
 errors = Hyrax::Workflow::WorkflowImporter.load_errors
@@ -43,3 +48,4 @@ rescue
 end
 
 puts "\n== Finished creating single tenant resources"
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,6 +17,9 @@ Rake::Task['hyrax:default_admin_set:create'].invoke
 # Import a flexible metadata profile
 AllinsonFlex::Importer.load_profile_from_path(path: Rails.root.join('config', 'metadata_profile', 'essi_short.yaml').to_s) unless AllinsonFlex::Profile.any?
 
+puts "\n== Creating default admin set"
+admin_set = AdminSet.find(AdminSet.find_or_create_default_admin_set_id)
+
 collection_types = Hyrax::CollectionType.all
 collection_types.each do |c|
   next unless c.title =~ /^translation missing/
@@ -25,3 +28,18 @@ collection_types.each do |c|
   c.save
   puts "#{oldtitle} changed to #{c.title}"
 end
+
+puts "\n== Loading workflows"
+Hyrax::Workflow::WorkflowImporter.load_workflows
+errors = Hyrax::Workflow::WorkflowImporter.load_errors
+abort("Failed to process all workflows:\n  #{errors.join('\n  ')}") unless errors.empty?
+
+puts "\n== Creating permission template"
+begin
+  permission_template = admin_set.permission_template
+  # If the permission template is missing we will need to run the create service
+rescue
+  Hyrax::AdminSetCreateService.new(admin_set: admin_set, creating_user: nil).create
+end
+
+puts "\n== Finished creating single tenant resources"


### PR DESCRIPTION
[Add set up to seeds](https://github.com/scientist-softserv/essi/commit/642dd04b1b02ee06480d2ec842d8bfef9e42a16e)

We took a lot of the set up scripts from the Louisville project and used
them here to get our environment set up.

ref: https://github.com/scientist-softserv/louisville-hyku/blob/main/db/seeds.rb

---

[Update gitignore](https://github.com/scientist-softserv/essi/commit/bc01dbd92bf917f78e36624ac74ae01ffa4221b0) 

When running tests, a ton of files get generated into
`/public/test-assets/` and we defintely don't want to track those.

---

[update seeds for admin user role](https://github.com/scientist-softserv/essi/commit/bc79e52cff3111c4d512fc16b9a3f0a245d943fd)